### PR TITLE
Fix for Skits 146 and 142

### DIFF
--- a/2_translated/skits/FC142.xml
+++ b/2_translated/skits/FC142.xml
@@ -83,22 +83,22 @@
     <Entry>
       <PointerOffset>9416</PointerOffset>
       <JapaneseText>あいつは……</JapaneseText>
-      <EnglishText/>
+      <EnglishText>She's...
+・She's our enemy!
+・You know her &lt;Ines&gt;?</EnglishText>
       <Notes/>
       <SpeakerId>4</SpeakerId>
       <Id>17</Id>
       <BubbleId>1</BubbleId>
       <SubId>1</SubId>
-      <Status>To Do</Status>
+      <Status>Editing</Status>
     </Entry>
     <Entry>
       <PointerOffset>9504</PointerOffset>
       <JapaneseText>女魔道士インカローズ……
 ・あいつは仇だッ！
 ・&lt;Ines&gt;も知ってたのか？</JapaneseText>
-      <EnglishText>The witch Incarose...
-・She's our enemy!
-・You know her?</EnglishText>
+      <EnglishText>The witch Incarose...</EnglishText>
       <Notes/>
       <SpeakerId>4</SpeakerId>
       <Id>4</Id>

--- a/tools/pythonlib/formats/tss.py
+++ b/tools/pythonlib/formats/tss.py
@@ -284,6 +284,11 @@ class Tss():
             #Insert all nodes
             [node.pack_node(tss, self.speaker_dict) for pointer_offset, node in self.struct_dict.items()]
 
+            #Update text section size
+            text_section_size = tss.tell() - self.strings_offset
+            tss.seek(24)
+            tss.write(struct.pack('<I', text_section_size))
+
             #Update TSS
             with FileIO(destination_path, 'wb') as f:
                f.write(tss.getvalue())

--- a/tools/pythonlib/formats/tss.py
+++ b/tools/pythonlib/formats/tss.py
@@ -60,6 +60,9 @@ class Tss():
                     offset = match_obj.start()
                     pointer_offset = offset + len(bytecode)
 
+                    # Fix for Skit 142 where there's a match for 00A304 at 0x3937
+                    if pointer_offset > self.strings_offset:
+                        continue
 
                     f.seek(pointer_offset, 0)
                     text_offset = struct.unpack('<H', f.read(2))[0] + self.strings_offset


### PR DESCRIPTION
**Skit 146 freeze fix**

<img width="872" height="367" alt="Screenshot 2025-09-07 225040" src="https://github.com/user-attachments/assets/ec4abff0-91b4-415e-8f3d-4a6f1c0b7ba7" />

The number at 0x18 in the .tss header contains the size of the section starting from the offset at 0xC in the header (the one assigned to self.strings_offset in tss.py) and ending at the end of the file. In the vanilla FC146.FCBIN, the size was 0x8B4.

At 20269F4, the game compares the relative pointer to the text entry (at r1) to the section size (at r0), and jumps to 2026B24 if r1 is greater. In other words, a check to make sure the text entry is inside the file.

Adjusting the size value fixes the freeze bug in Skit 146 (and possibly in other skits).